### PR TITLE
Add API_PRIVATE_ACCESS Env Variable at Deployment

### DIFF
--- a/aviatrix-aws-existing-controller-ha.json
+++ b/aviatrix-aws-existing-controller-ha.json
@@ -22,7 +22,8 @@
          "SubnetParam" : { "default" : "Enter one or more subnets in different Availability zones within that VPC." },
          "AviatrixTagParam": { "default" : "Enter Name tag of the existing Aviatrix Controller instance." },
          "S3BucketBackupParam": { "default" : "Enter S3 Bucket which will be used to store backup files." },
-         "NotifEmailParam": { "default" : "Enter an email to receive notifications for autoscaling group events" }
+         "NotifEmailParam": { "default" : "Enter an email to receive notifications for autoscaling group events" },
+         "ApiPrivateAccess": { "default" : "Enter True to enable Private IP Access to Controller for High Availabilty failover" }
       }
     }
   },
@@ -52,6 +53,16 @@
       {
         "Type": "String",
         "Description": "Enter an email to receive notifications for autoscaling group events"
+      },
+      "ApiPrivateAccess":
+      {
+        "Type": "String",
+        "AllowedValues": [
+          "True",
+          "False"
+        ],
+        "Description": "Enter True to enable Private IP Access to Controller for High Availabilty failover",
+        "Default": "False"
       }
   },
   "Resources" :
@@ -156,6 +167,7 @@
               "AVIATRIX_TAG" : { "Ref" : "AviatrixTagParam" },
               "SUBNETLIST" : {"Fn::Join": [",", { "Ref": "SubnetParam" }]},
               "S3_BUCKET_BACK" : { "Ref" : "S3BucketBackupParam" },
+              "API_PRIVATE_ACCESS" : { "Ref" : "ApiPrivateAccess" },
               "NOTIF_EMAIL" : { "Ref" : "NotifEmailParam" }
             }
           },


### PR DESCRIPTION
Add the API_PRIVATE_ACCESS Environment Variable into the Deployment JSON to allow control over Private IP Access when the SETUP_HA function creates the Auto Scaling Launch Configuration.  Also, allow the user to control the setting at launch instead of having to modify the Lambda after deployment.