### PR TITLE
AVX-60919 Update Controller HA to work with parametrized registry

### DIFF
--- a/aviatrix_ha/csp/instance.py
+++ b/aviatrix_ha/csp/instance.py
@@ -1,5 +1,7 @@
 """ CSP APis related to instances"""
 
+import base64
+
 import boto3
 import botocore
 
@@ -35,6 +37,7 @@ def get_controller_instance(ec2_client, instance_name, inst_id):
             str(err),
         )
         print(describe_err)
+
     return describe_err, controller_instanceobj
 
 
@@ -76,3 +79,15 @@ def verify_iam(controller_instanceobj):
     if not iam_arn:
         return False
     return True
+
+
+def get_user_data(ec2_client, controller_instanceobj) -> str:
+    try:
+        user_data = ec2_client.describe_instance_attribute(
+            InstanceId=controller_instanceobj["InstanceId"], Attribute="userData"
+        )["UserData"]["Value"]
+        user_data = base64.b64decode(user_data).decode("utf-8")
+        return user_data
+    except Exception as err:
+        print(str(err))
+    return ""

--- a/aviatrix_ha/csp/lambda_c.py
+++ b/aviatrix_ha/csp/lambda_c.py
@@ -51,6 +51,7 @@ def set_environ(client, lambda_client, controller_instanceobj, context, eip=None
     ctrl_subnet = controller_instanceobj["SubnetId"]
     priv_ip = controller_instanceobj.get("NetworkInterfaces")[0].get("PrivateIpAddress")
     iam_arn = controller_instanceobj.get("IamInstanceProfile", {}).get("Arn", "")
+    user_data = controller_instanceobj.get("UserData", "")
     mon_bool = (
         controller_instanceobj.get("Monitoring", {}).get("State", "disabled")
         != "disabled"
@@ -119,6 +120,7 @@ def set_environ(client, lambda_client, controller_instanceobj, context, eip=None
         "DISABLE_API_TERMINATION": os.environ.get("DISABLE_API_TERMINATION", "False"),
         "SERVICE_URL": os.environ.get("SERVICE_URL", ""),
         "EBS_OPT": ebs_opt,
+        "USER_DATA": user_data,
         # 'AVIATRIX_USER_BACK': os.environ.get('AVIATRIX_USER_BACK'),
         # 'AVIATRIX_PASS_BACK': os.environ.get('AVIATRIX_PASS_BACK'),
     }
@@ -162,6 +164,7 @@ def update_env_dict(lambda_client, context, replace_dict):
         "DISABLE_API_TERMINATION": os.environ.get("DISABLE_API_TERMINATION", "False"),
         "SERVICE_URL": os.environ.get("SERVICE_URL", ""),
         "EBS_OPT": os.environ.get("EBS_OPT", "False"),
+        "USER_DATA": os.environ.get("USER_DATA", ""),
         # 'AVIATRIX_USER_BACK': os.environ.get('AVIATRIX_USER_BACK'),
         # 'AVIATRIX_PASS_BACK': os.environ.get('AVIATRIX_PASS_BACK'),
     }

--- a/aviatrix_ha/handlers/asg/handler.py
+++ b/aviatrix_ha/handlers/asg/handler.py
@@ -10,7 +10,7 @@ from aviatrix_ha.handlers.cft.handler import delete_resources, setup_ha
 def handle_sns_event(
     describe_err, event, client, lambda_client, controller_instanceobj, context
 ):
-    """Handle an autoscaling group evevnt which is sent by SNS"""
+    """Handle an autoscaling group event which is sent by SNS"""
     if describe_err:
         try:
             sns_msg_event = (json.loads(event["Records"][0]["Sns"]["Message"]))["Event"]
@@ -42,7 +42,15 @@ def handle_sns_event(
         ami_id = os.environ.get("AMI_ID")
         inst_type = os.environ.get("INST_TYPE")
         key_name = os.environ.get("KEY_NAME")
+        user_data = os.environ.get("USER_DATA")
         delete_resources(None, detach_instances=False)
         setup_ha(
-            ami_id, inst_type, None, key_name, [sg_id], context, attach_instance=False
+            ami_id,
+            inst_type,
+            None,
+            key_name,
+            [sg_id],
+            context,
+            user_data,
+            attach_instance=False,
         )

--- a/tests/terraform/e2e_controller/api.tf
+++ b/tests/terraform/e2e_controller/api.tf
@@ -8,6 +8,8 @@ resource "terracurl_request" "login" {
   name            = "login"
   url             = "https://${module.my_controller.controller_public_ip}/v2/api"
   method          = "POST"
+  destroy_url     = "https://checkip.amazonaws.com"
+  destroy_method  = "GET"
   skip_tls_verify = true
   request_body = jsonencode({
     "action" : "login",
@@ -44,6 +46,8 @@ resource "terracurl_request" "setup_account_profile" {
   name            = "setup_account_profile"
   url             = "https://${module.my_controller.controller_public_ip}/v2/api"
   method          = "POST"
+  destroy_url     = "https://checkip.amazonaws.com"
+  destroy_method  = "GET"
   skip_tls_verify = true
   request_body = jsonencode({
     "action" : "setup_account_profile",
@@ -83,6 +87,8 @@ resource "terracurl_request" "enable_cloudn_backup_config" {
   name            = "enable_cloudn_backup_config"
   url             = "https://${module.my_controller.controller_public_ip}/v2/api"
   method          = "POST"
+  destroy_url     = "https://checkip.amazonaws.com"
+  destroy_method  = "GET"
   skip_tls_verify = true
   request_body = jsonencode({
     "action" : "enable_cloudn_backup_config",

--- a/tests/terraform/e2e_controller/ha.tf
+++ b/tests/terraform/e2e_controller/ha.tf
@@ -1,9 +1,17 @@
+data "aws_instance" "controller_instance" {
+    instance_id = module.my_controller.controller_instance_id
+}
+
+data "aws_subnet" "controller_subnet" {
+    id = data.aws_instance.controller_instance.subnet_id
+}
+
 resource "aws_cloudformation_stack" "controller_ha" {
     name = "ControllerHA"
 
     parameters = {
-        VPCParam = module.my_controller.controller_vpc_id
-        SubnetParam = module.my_controller.controller_subnet_id
+        VPCParam = data.aws_subnet.controller_subnet.vpc_id
+        SubnetParam = data.aws_instance.controller_instance.subnet_id
         AviatrixTagParam = module.my_controller.controller_name
         S3BucketBackupParam = aws_s3_bucket.backup_bucket.bucket
         NotifEmailParam = "nobody@aviatrix.com"

--- a/tests/terraform/e2e_controller/main.tf
+++ b/tests/terraform/e2e_controller/main.tf
@@ -23,30 +23,31 @@ locals {
 }
 
 module "my_controller" {
-  source = "git::https://github.com/AviatrixSystems/terraform-aviatrix-aws-controlplane?ref=no-cft"
+  source = "git::https://github.com/terraform-aviatrix-modules/terraform-aviatrix-aws-controlplane"
 
+  access_account_name       = ""
   account_email             = var.admin_email
   customer_id               = var.customer_id
   controller_admin_email    = var.admin_email
   controller_admin_password = local.admin_password
   incoming_ssl_cidrs        = var.incoming_ssl_cidrs
 
-  controller_ami_id = var.controller_ami_id == "" ? data.aws_ami.latest_controller.id : var.controller_ami_id
-  controller_user_data = templatefile("${path.module}/cloud-config.yaml", {
-    software_version          = var.controller_version
-    use_containerized_gateway = var.use_containerized_gateway ? "true" : "false"
-  })
-  controller_wait_for_setup_duration = "0s"
-  use_existing_keypair               = var.key_pair_name == "" ? false : true
-  key_pair_name                      = var.key_pair_name == "" ? "" : var.key_pair_name
+  controller_ami_id               = var.controller_ami_id == "" ? data.aws_ami.latest_controller.id : var.controller_ami_id
+  controller_version              = var.controller_version
+  controller_use_existing_keypair = var.key_pair_name == "" ? false : true
+  controller_key_pair_name        = var.key_pair_name == "" ? "" : var.key_pair_name
 
   module_config = {
-    controller_iam            = false,
+    iam_roles                 = false
+    account_onboarding        = false
     controller_deployment     = var.setup_controller
     controller_initialization = var.setup_controller
     copilot_deployment        = var.setup_copilot
     copilot_initialization    = var.setup_copilot
   }
+
+  environment         = var.environment
+  registry_auth_token = var.registry_auth_token
 }
 
 resource "aws_s3_bucket" "backup_bucket" {

--- a/tests/terraform/e2e_controller/variables.tf
+++ b/tests/terraform/e2e_controller/variables.tf
@@ -50,3 +50,24 @@ variable "setup_copilot" {
   type        = bool
   default     = false
 }
+
+# terraform-docs-ignore
+variable "environment" {
+  description = "Determines the deployment environment. For internal use only."
+  type        = string
+  default     = "prod"
+  nullable    = false
+
+  validation {
+    condition     = contains(["prod", "staging"], var.environment)
+    error_message = "The environment must be either 'prod' or 'staging'."
+  }
+}
+
+# terraform-docs-ignore
+variable "registry_auth_token" {
+  description = "The token used to authenticate to the controller artifact registry. For internal use only."
+  type        = string
+  default     = ""
+  nullable    = false
+}


### PR DESCRIPTION
Instead of having a fixed cloud-init config, setup the ASG instance
template to use the cloud-init passed into the original instance. This
way if the original instance had specific configurations, they will be
inherited by the newly brought up instance.

Update the e2e test to use the new official AWS controlplane module.
