### PR TITLE
AVX-60919 Don't disassociate the temporary SG for all Lambda calls

### DIFF
--- a/aviatrix_ha/__init__.py
+++ b/aviatrix_ha/__init__.py
@@ -74,7 +74,7 @@ def _lambda_handler(event, context):
     lambda_client = boto3.client("lambda")
 
     tmp_sg = os.environ.get("TMP_SG_GRP", "")
-    if tmp_sg:
+    if event_type != EventType.FUNCTION and tmp_sg:
         print(f"Lambda probably did not complete last time. Reverting {tmp_sg}")
         update_env_dict(lambda_client, context, {"TMP_SG_GRP": ""})
         restore_security_group_access(client, tmp_sg)

--- a/tests/terraform/e2e_controller/main.tf
+++ b/tests/terraform/e2e_controller/main.tf
@@ -8,6 +8,10 @@ data "aws_ami" "latest_controller" {
   }
 }
 
+data "http" "my_ip" {
+  url = "http://ipv4.icanhazip.com"
+}
+
 # try to satisfy the controller's password strength meter by combining
 # two passwords with a special char
 resource "random_password" "admin" {
@@ -30,7 +34,7 @@ module "my_controller" {
   customer_id               = var.customer_id
   controller_admin_email    = var.admin_email
   controller_admin_password = local.admin_password
-  incoming_ssl_cidrs        = var.incoming_ssl_cidrs
+  incoming_ssl_cidrs        = length(var.incoming_ssl_cidrs) > 0 ? var.incoming_ssl_cidrs : ["${chomp(data.http.my_ip.response_body)}/32"]
 
   controller_ami_id               = var.controller_ami_id == "" ? data.aws_ami.latest_controller.id : var.controller_ami_id
   controller_version              = var.controller_version

--- a/tests/terraform/e2e_controller/variables.tf
+++ b/tests/terraform/e2e_controller/variables.tf
@@ -12,7 +12,7 @@ variable "customer_id" {
 variable "incoming_ssl_cidrs" {
   description = "List of CIDRs to allow incoming connections from"
   type        = list(string)
-  default     = ["0.0.0.0/0"]
+  default     = []
 }
 
 variable "controller_ami_id" {


### PR DESCRIPTION
In cases where the Lambda has to setup a temporary SG during controller HA, the previous code used to remove the SG if the Lambda gets retriggered, in an attempt to cleanup after incomplete executions. We should do this if the Lambda is triggered by (HTTP) function events (e.g. used to retrieve the software version number).

Update the e2e terraform to use a non-0.0.0.0/0 default SG rule so we can exercise this path.