### PR TITLE
AVX-78155: Fix multiple controller instances with same name tag causing HA setup fail to retrieve the right backup file

### DIFF
--- a/aviatrix_ha/__init__.py
+++ b/aviatrix_ha/__init__.py
@@ -3,6 +3,7 @@
 # pylint: disable=too-many-lines,too-many-locals,too-many-branches,too-many-return-statements
 # pylint: disable=too-many-statements,too-many-arguments,broad-except
 import enum
+import json
 import os
 import traceback
 from typing import Any
@@ -61,6 +62,22 @@ def _get_event_type(event: dict[str, Any]) -> EventType:
     return EventType.UNKNOWN
 
 
+def _get_launched_instance_id(event: dict[str, Any]) -> str:
+    """Return the instance id from an ASG EC2_INSTANCE_LAUNCH SNS event.
+
+    On failover the ASG launches a new controller and tells us its exact
+    instance id. That id is authoritative for picking the controller to
+    restore. Returns "" for any other event.
+    """
+    try:
+        sns_msg = json.loads(event["Records"][0]["Sns"]["Message"])
+        if sns_msg.get("Event") == "autoscaling:EC2_INSTANCE_LAUNCH":
+            return sns_msg.get("EC2InstanceId", "")
+    except (AttributeError, IndexError, KeyError, TypeError, ValueError):
+        pass
+    return ""
+
+
 def _lambda_handler(event: dict[str, Any], context: Any) -> Any:
     """Entry point of the lambda script without exception handling
     This lambda function will serve muliple kinds of requests:
@@ -70,28 +87,39 @@ def _lambda_handler(event: dict[str, Any], context: Any) -> Any:
     3) function_request - request to the function url
     """
     event_type = _get_event_type(event)
+
+    # A function URL request (controller asking for its version) does not need
+    # the controller instance, so handle it before any EC2 discovery. This also
+    # avoids confusing cloudwatch log "can't determine which instance" error when the
+    # Name tag is ambiguous, since that lookup is irrelevant here.
+    if event_type == EventType.FUNCTION:
+        return handle_function_event(event, context)
+
     client = boto3.client("ec2")
     lambda_client = boto3.client("lambda")
 
     tmp_sg = os.environ.get("TMP_SG_GRP", "")
     tmp_sgr = os.environ.get("TMP_SG_RULE", "")
-    if event_type != EventType.FUNCTION and tmp_sg and tmp_sgr:
+    if tmp_sg and tmp_sgr:
         print(
             f"Lambda probably did not complete last time. Reverting {tmp_sg}/{tmp_sgr}"
         )
         update_env_dict(lambda_client, context, {"TMP_SG_GRP": "", "TMP_SG_RULE": ""})
         remove_temp_security_group_access(client, tmp_sg, tmp_sgr)
     instance_name = os.environ.get("AVIATRIX_TAG", "")
-    inst_id = os.environ.get("INST_ID", "")
     # CTRL_PRIV_IP is the user-provided controller private IP, used to
     # distinguish when multiple instances share the Name tag.
     ctrl_priv_ip = os.environ.get("CTRL_PRIV_IP", "")
+    # On a failover launch the SNS event tells us exactly which instance the ASG
+    # created. That id is authoritative, so we look the controller up directly
+    # by it instead of by the (possibly ambiguous) Name tag.
+    launched_inst_id = _get_launched_instance_id(event)
     print(
-        f"Trying describe with name {instance_name}, ID {inst_id}, and "
-        f"private IP {ctrl_priv_ip}"
+        f"Trying describe with name {instance_name}, "
+        f"private IP {ctrl_priv_ip}, launched instance {launched_inst_id}"
     )
     describe_err, controller_instanceobj = get_controller_instance(
-        client, instance_name, inst_id, ctrl_priv_ip
+        client, instance_name, launched_inst_id, ctrl_priv_ip
     )
 
     if event_type == EventType.CFT:
@@ -108,8 +136,6 @@ def _lambda_handler(event: dict[str, Any], context: Any) -> Any:
         return handle_sns_event(
             describe_err, event, client, lambda_client, controller_instanceobj, context
         )
-    elif event_type == EventType.FUNCTION:
-        return handle_function_event(event, context)
     else:
         print("Unknown source. Not from CFT or SNS")
         return False

--- a/aviatrix_ha/__init__.py
+++ b/aviatrix_ha/__init__.py
@@ -83,9 +83,15 @@ def _lambda_handler(event: dict[str, Any], context: Any) -> Any:
         remove_temp_security_group_access(client, tmp_sg, tmp_sgr)
     instance_name = os.environ.get("AVIATRIX_TAG", "")
     inst_id = os.environ.get("INST_ID", "")
-    print(f"Trying describe with name {instance_name} and ID {inst_id}")
+    # CTRL_PRIV_IP is the user-provided controller private IP, used to
+    # distinguish when multiple instances share the Name tag.
+    ctrl_priv_ip = os.environ.get("CTRL_PRIV_IP", "")
+    print(
+        f"Trying describe with name {instance_name}, ID {inst_id}, and "
+        f"private IP {ctrl_priv_ip}"
+    )
     describe_err, controller_instanceobj = get_controller_instance(
-        client, instance_name, inst_id
+        client, instance_name, inst_id, ctrl_priv_ip
     )
 
     if event_type == EventType.CFT:

--- a/aviatrix_ha/csp/instance.py
+++ b/aviatrix_ha/csp/instance.py
@@ -1,39 +1,84 @@
 """ CSP APis related to instances"""
 
 import base64
-from typing import Any
 
 import boto3
 import botocore
 from types_boto3_ec2.client import EC2Client
 from types_boto3_ec2.type_defs import InstanceTypeDef
 
+from aviatrix_ha.errors.exceptions import AvxError
+
 
 def get_controller_instance(
-    ec2_client: EC2Client, instance_name: str, inst_id: str
+    ec2_client: EC2Client, instance_name: str, inst_id: str = "", priv_ip: str = ""
 ) -> tuple[str | None, InstanceTypeDef]:
-    """Find the controller instance based on name or id"""
-    controller_instanceobj: InstanceTypeDef = {}
-    describe_err = None
+    """Return the controller instance to manage, or an error if it is unclear.
+
+    The Name tag is not unique: an account can have several running instances
+    with the same Name tag (in different VPCs, subnets, or security groups).
+    Selecting the first match can pick the wrong controller, and HA then reads
+    that controller's backup by its private IP, restoring the wrong backup.
+
+    The private IP (provided by the user at stack creation) is unique within a
+    VPC, so it is used to choose between instances that share the Name tag. It
+    is only used to choose between multiple matches; it never discards a single
+    match. During failover the replacement instance has a new private IP that
+    will not equal the provided one, but it is then the only instance with the
+    Name tag and is selected.
+
+    Steps:
+      1. List running instances with the given Name tag.
+      2. If more than one is found, keep only the one whose private IP matches
+         priv_ip (if priv_ip is set and matches one of them).
+      3. If exactly one instance remains, return it.
+      4. Otherwise, if inst_id is set, return that instance. This also finds a
+         controller that step 1 misses, for example one that is stopped or
+         whose Name tag was changed.
+      5. If no single instance can be determined, return a descriptive error.
+    """
     try:
-        try:
-            controller_instanceobj = ec2_client.describe_instances(
-                Filters=[
-                    {"Name": "instance-state-name", "Values": ["running"]},
-                    {"Name": "tag:Name", "Values": [instance_name]},
-                ]
-            )["Reservations"][0]["Instances"][0]
-        except IndexError:
-            if inst_id:
-                print(
-                    "Can't find Controller instance with name tag %s, "
-                    "trying with inst id %s" % (instance_name, inst_id)
-                )
-                controller_instanceobj = ec2_client.describe_instances(
-                    InstanceIds=[inst_id]
-                )["Reservations"][0]["Instances"][0]
-            else:
-                raise
+        reservations = ec2_client.describe_instances(
+            Filters=[
+                {"Name": "instance-state-name", "Values": ["running"]},
+                {"Name": "tag:Name", "Values": [instance_name]},
+            ]
+        )["Reservations"]
+
+        # A Name tag can match instances across multiple reservations (each launch is
+        # its own reservation), so flatten before counting
+        instances = [inst for res in reservations for inst in res.get("Instances", [])]
+
+        if len(instances) > 1 and priv_ip:
+            instances = [
+                inst for inst in instances if inst.get("PrivateIpAddress") == priv_ip
+            ] or instances
+
+        if len(instances) == 1:
+            return None, instances[0]
+
+        if inst_id:
+            print(
+                f"Name tag '{instance_name}' resolved to {len(instances)} running "
+                f"instances; using recorded instance id {inst_id}"
+            )
+            instance = ec2_client.describe_instances(InstanceIds=[inst_id])[
+                "Reservations"
+            ][0]["Instances"][0]
+            return None, instance
+
+        if not instances:
+            raise AvxError(
+                f"No running controller instance found with Name tag "
+                f"'{instance_name}'."
+            )
+        ids = ", ".join(i["InstanceId"] for i in instances)
+        raise AvxError(
+            f"Found {len(instances)} running instances with Name tag "
+            f"'{instance_name}': {ids}. HA cannot determine which instance to "
+            f"manage. Please ensure the controller Name tag is unique or provide "
+            f"the correct controller private IP."
+        )
     except Exception as err:
         inst_id_err = " or inst id %s" % inst_id if inst_id else ""
         describe_err = "Can't find Controller instance with name tag %s%s. %s" % (
@@ -42,8 +87,7 @@ def get_controller_instance(
             str(err),
         )
         print(describe_err)
-
-    return describe_err, controller_instanceobj
+        return describe_err, {}
 
 
 def enable_t2_unlimited(client: EC2Client, inst_id: str) -> None:

--- a/aviatrix_ha/csp/instance.py
+++ b/aviatrix_ha/csp/instance.py
@@ -15,27 +15,20 @@ def get_controller_instance(
 ) -> tuple[str | None, InstanceTypeDef]:
     """Return the controller instance to manage, or an error if it is unclear.
 
-    The Name tag is not unique: an account can have several running instances
-    with the same Name tag (in different VPCs, subnets, or security groups).
-    Selecting the first match can pick the wrong controller, and HA then reads
-    that controller's backup by its private IP, restoring the wrong backup.
+    inst_id, when set, is an authoritative identifier and is used directly. On
+    failover the ASG tells us (via the SNS event) the exact instance it just
+    launched; that is passed here so we restore onto the new controller rather
+    than guessing from the Name tag. We must NOT fall back to a previously
+    recorded instance id, because at failover that points at the old, now
+    terminated controller - selecting it makes the restore step think the
+    controller is "already saved" and skip restoring.
 
-    The private IP (provided by the user at stack creation) is unique within a
-    VPC, so it is used to choose between instances that share the Name tag. It
-    is only used to choose between multiple matches; it never discards a single
-    match. During failover the replacement instance has a new private IP that
-    will not equal the provided one, but it is then the only instance with the
-    Name tag and is selected.
-
-    Steps:
-      1. List running instances with the given Name tag.
-      2. If more than one is found, keep only the one whose private IP matches
-         priv_ip (if priv_ip is set and matches one of them).
-      3. If exactly one instance remains, return it.
-      4. Otherwise, if inst_id is set, return that instance. This also finds a
-         controller that step 1 misses, for example one that is stopped or
-         whose Name tag was changed.
-      5. If no single instance can be determined, return a descriptive error.
+    Without inst_id we find the controller by its Name tag. The Name tag is not
+    unique: an account can have several running instances with the same Name
+    tag. The user-supplied private IP (unique within a VPC) is used to choose
+    between such matches; it only narrows multiple matches and never discards a
+    single match. If the tag cannot be resolved to exactly one instance, a
+    descriptive error is returned instead of guessing.
     """
     try:
         reservations = ec2_client.describe_instances(
@@ -58,10 +51,7 @@ def get_controller_instance(
             return None, instances[0]
 
         if inst_id:
-            print(
-                f"Name tag '{instance_name}' resolved to {len(instances)} running "
-                f"instances; using recorded instance id {inst_id}"
-            )
+            print(f"Looking up controller by instance id {inst_id}")
             instance = ec2_client.describe_instances(InstanceIds=[inst_id])[
                 "Reservations"
             ][0]["Instances"][0]

--- a/aviatrix_ha/csp/lambda_c.py
+++ b/aviatrix_ha/csp/lambda_c.py
@@ -134,6 +134,9 @@ def set_environ(
         # contain the previous private IP.
         "OLD_PRIV_IP": os.environ.get("PRIV_IP") or priv_ip,
         "INST_ID": inst_id,
+        # Preserve the user-supplied controller private IP.
+        # Failover refreshes it explicitly.
+        "CTRL_PRIV_IP": os.environ.get("CTRL_PRIV_IP", ""),
         "SUBNETLIST": os.environ.get("SUBNETLIST", ""),
         "S3_BUCKET_BACK": os.environ.get("S3_BUCKET_BACK", ""),
         "S3_BUCKET_REGION": os.environ.get("S3_BUCKET_REGION", ""),
@@ -181,6 +184,7 @@ def update_env_dict(
         "PRIV_IP": os.environ.get("PRIV_IP", ""),
         "OLD_PRIV_IP": os.environ.get("OLD_PRIV_IP", ""),
         "INST_ID": os.environ.get("INST_ID", ""),
+        "CTRL_PRIV_IP": os.environ.get("CTRL_PRIV_IP", ""),
         "SUBNETLIST": os.environ.get("SUBNETLIST", ""),
         "S3_BUCKET_BACK": os.environ.get("S3_BUCKET_BACK", ""),
         "S3_BUCKET_REGION": os.environ.get("S3_BUCKET_REGION", ""),

--- a/aviatrix_ha/csp/s3.py
+++ b/aviatrix_ha/csp/s3.py
@@ -96,6 +96,15 @@ def verify_backup_file(controller_instanceobj: InstanceTypeDef) -> tuple[bool, s
             if err.response["Error"]["Code"] == "404":
                 print("The object %s does not exist." % s3_file)
                 return False, ""
+            if err.response["Error"]["Code"] == "403":
+                # With s3:ListBucket, a missing object returns 404; a 403 here
+                # means the object exists but is unreadable, could due to object ownership,
+                # bucket policy, or KMS, not a missing backup.
+                print(
+                    "Access denied (403) reading %s. Check S3 object ownership,"
+                    " bucket policy, and KMS permissions for the Lambda role." % s3_file
+                )
+                return False, ""
             print(str(err))
             return False, ""
     except Exception as err:

--- a/aviatrix_ha/handlers/asg/event.py
+++ b/aviatrix_ha/handlers/asg/event.py
@@ -228,6 +228,9 @@ class HAEventHandler:
             self.context,
             self.public_ip,
         )
+        update_env_dict(
+            self.lambda_client, self.context, {"CTRL_PRIV_IP": self.private_ip}
+        )
         return HAStepResult.CONTINUE
 
     def remove_temp_sg_rule_step(self) -> HAStepResult:

--- a/cft/aviatrix-aws-existing-controller-ha-v4.json
+++ b/cft/aviatrix-aws-existing-controller-ha-v4.json
@@ -13,7 +13,7 @@
         },
         {
           "Label" : { "default":"Aviatrix Controller Backup Configuration" },
-          "Parameters" : [ "AviatrixTagParam", "CustomAviatrixAppRoleName", "CustomAviatrixEC2RoleName", "S3BucketBackupParam", "AwsAccessKeyParam", "AwsSecretKeyParam", "NotifEmailParam" ]
+          "Parameters" : [ "AviatrixTagParam", "ControllerPrivateIpParam", "CustomAviatrixAppRoleName", "CustomAviatrixEC2RoleName", "S3BucketBackupParam", "AwsAccessKeyParam", "AwsSecretKeyParam", "NotifEmailParam" ]
         }
       ],
       "ParameterLabels" :
@@ -22,6 +22,7 @@
          "SubnetParam" : { "default" : "Enter one or more subnets in different Availability zones within that VPC." },
          "SecurityGroupParam": { "default" : "Enter the security group of existing controller instance." },
          "AviatrixTagParam": { "default" : "Enter Name tag of the existing Aviatrix Controller instance." },
+         "ControllerPrivateIpParam": { "default" : "Enter the private IP address of the existing Aviatrix Controller instance." },
          "S3BucketBackupParam": { "default" : "Enter S3 Bucket which will be used to store backup files." },
          "NotifEmailParam": { "default" : "Enter an email to receive notifications for autoscaling group events" },
          "PrivateAccess": { "default" : "Enter True to enable Private IP Access from lambda to the Controller. Please note that you have to attach the Lambda to the VPC subnet and ensure lambda has internet access via EIP/NAT" },
@@ -46,6 +47,13 @@
     {
       "Type": "String",
       "Description": "Enter the existing controller instance name. It should contain only letters, numbers, hyphens, or underscores. No spaces allowed"
+    },
+    "ControllerPrivateIpParam":
+    {
+      "Type": "String",
+      "Description": "Enter the private IP address of the existing Aviatrix Controller instance. This uniquely identifies the controller when multiple instances share the same Name tag.",
+      "AllowedPattern": "^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$",
+      "ConstraintDescription": "Must be a valid IPv4 format (e.g. 10.0.0.52)."
     },
     "SecurityGroupParam":
     {
@@ -184,6 +192,7 @@
                         "iam:CreateServiceLinkedRole",
                         "s3:GetBucketLocation",
                         "s3:GetObject",
+                        "s3:ListBucket",
                         "elasticloadbalancing:DescribeTargetGroups",
                         "elasticloadbalancing:DescribeTargetHealth"
                     ],
@@ -202,6 +211,7 @@
           "Environment" : {
             "Variables": {
               "AVIATRIX_TAG" : { "Ref" : "AviatrixTagParam" },
+              "CTRL_PRIV_IP" : { "Ref" : "ControllerPrivateIpParam" },
               "AWS_ROLE_APP_NAME" : { "Ref" : "CustomAviatrixAppRoleName" },
               "AWS_ROLE_EC2_NAME" : { "Ref" : "CustomAviatrixEC2RoleName" },
               "SUBNETLIST" : {"Fn::Join": [",", { "Ref": "SubnetParam" }]},

--- a/tests/test_get_controller_instance.py
+++ b/tests/test_get_controller_instance.py
@@ -1,0 +1,112 @@
+"""Tests for aviatrix_ha.csp.instance.get_controller_instance.
+
+These cover controller lookup, in particular the case where multiple running
+instances share the same Name tag and HA must not select the wrong one.
+"""
+
+import boto3
+import moto
+import pytest
+
+from aviatrix_ha.csp.instance import get_controller_instance
+
+NAME_TAG = "my-controller"
+MOTO_AMI_ID = "ami-12c6146b"
+
+
+def run_controller_instance(ec2_client, name, subnet_id=None, private_ip=None):
+    """Launch a moto instance tagged with the given Name and return it."""
+    kwargs = {
+        "ImageId": MOTO_AMI_ID,
+        "MinCount": 1,
+        "MaxCount": 1,
+        "TagSpecifications": [
+            {
+                "ResourceType": "instance",
+                "Tags": [{"Key": "Name", "Value": name}],
+            }
+        ],
+    }
+    if subnet_id:
+        kwargs["SubnetId"] = subnet_id
+    if private_ip:
+        kwargs["PrivateIpAddress"] = private_ip
+    return ec2_client.run_instances(**kwargs)["Instances"][0]
+
+
+@pytest.fixture
+def ec2_client():
+    with moto.mock_aws():
+        yield boto3.client("ec2", region_name="us-east-1")
+
+
+def test_single_instance_is_returned(ec2_client):
+    """One running instance with the Name tag is returned with no error."""
+    instance = run_controller_instance(ec2_client, NAME_TAG)
+    err, found = get_controller_instance(ec2_client, NAME_TAG)
+    assert err is None
+    assert found["InstanceId"] == instance["InstanceId"]
+
+
+def test_matching_private_ip_selects_the_right_instance(ec2_client):
+    """With multiple Name tag matches, priv_ip selects the intended instance."""
+    # Two subnets so the two instances get distinct private IPs.
+    vpc_id = ec2_client.create_vpc(CidrBlock="10.0.0.0/16")["Vpc"]["VpcId"]
+    subnet_one = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.1.0/24")[
+        "Subnet"
+    ]["SubnetId"]
+    subnet_two = ec2_client.create_subnet(VpcId=vpc_id, CidrBlock="10.0.2.0/24")[
+        "Subnet"
+    ]["SubnetId"]
+    intended_instance = run_controller_instance(
+        ec2_client, NAME_TAG, subnet_id=subnet_one, private_ip="10.0.1.52"
+    )
+    run_controller_instance(
+        ec2_client, NAME_TAG, subnet_id=subnet_two, private_ip="10.0.2.99"
+    )
+
+    err, found = get_controller_instance(ec2_client, NAME_TAG, priv_ip="10.0.1.52")
+    assert err is None
+    assert found["InstanceId"] == intended_instance["InstanceId"]
+
+
+def test_multiple_matches_without_private_ip_returns_error(ec2_client):
+    """Multiple Name tag matches and no private IP -> error, no guess."""
+    run_controller_instance(ec2_client, NAME_TAG)
+    run_controller_instance(ec2_client, NAME_TAG)
+
+    err, found = get_controller_instance(ec2_client, NAME_TAG)
+    assert err is not None
+    assert "2 running instances" in err
+    assert found == {}
+
+
+def test_private_ip_matching_none_returns_error(ec2_client):
+    """If priv_ip matches none of the instances, do not select one."""
+    run_controller_instance(ec2_client, NAME_TAG)
+    run_controller_instance(ec2_client, NAME_TAG)
+
+    err, found = get_controller_instance(ec2_client, NAME_TAG, priv_ip="10.255.255.255")
+    assert err is not None
+    assert "cannot determine which instance" in err.lower()
+    assert found == {}
+
+
+def test_instance_id_is_used_when_name_tag_not_found(ec2_client):
+    """A controller the Name tag lookup misses is found through inst_id."""
+    # Instance tagged with a different name -> lookup for NAME_TAG finds nothing.
+    instance = run_controller_instance(ec2_client, "renamed-controller")
+
+    err, found = get_controller_instance(
+        ec2_client, NAME_TAG, inst_id=instance["InstanceId"]
+    )
+    assert err is None
+    assert found["InstanceId"] == instance["InstanceId"]
+
+
+def test_no_match_and_no_instance_id_returns_error(ec2_client):
+    """Nothing found -> error message set, empty instance object."""
+    err, found = get_controller_instance(ec2_client, NAME_TAG)
+    assert err is not None
+    assert NAME_TAG in err
+    assert found == {}

--- a/tests/test_get_controller_instance.py
+++ b/tests/test_get_controller_instance.py
@@ -92,21 +92,27 @@ def test_private_ip_matching_none_returns_error(ec2_client):
     assert found == {}
 
 
-def test_instance_id_is_used_when_name_tag_not_found(ec2_client):
-    """A controller the Name tag lookup misses is found through inst_id."""
-    # Instance tagged with a different name -> lookup for NAME_TAG finds nothing.
-    instance = run_controller_instance(ec2_client, "renamed-controller")
-
-    err, found = get_controller_instance(
-        ec2_client, NAME_TAG, inst_id=instance["InstanceId"]
-    )
-    assert err is None
-    assert found["InstanceId"] == instance["InstanceId"]
-
-
 def test_no_match_and_no_instance_id_returns_error(ec2_client):
     """Nothing found -> error message set, empty instance object."""
     err, found = get_controller_instance(ec2_client, NAME_TAG)
     assert err is not None
     assert NAME_TAG in err
     assert found == {}
+
+
+def test_instance_id_is_authoritative_over_name_tag(ec2_client):
+    """When inst_id is given it is used directly, even with a duplicate tag.
+
+    Reproduces the failover case: a second instance shares the Name tag. The ASG
+    reports the exact id of the instance it just launched, and that instance
+    must be selected directly - not resolved through the ambiguous Name tag - so
+    restore runs against the new controller instead of being skipped.
+    """
+    run_controller_instance(ec2_client, NAME_TAG)
+    launched = run_controller_instance(ec2_client, NAME_TAG)
+
+    err, found = get_controller_instance(
+        ec2_client, NAME_TAG, inst_id=launched["InstanceId"]
+    )
+    assert err is None
+    assert found["InstanceId"] == launched["InstanceId"]

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -69,13 +69,16 @@ def _cft_message(request_type, lambda_arn):
     }
 
 
-def _sns_message(event_type):
+def _sns_message(event_type, instance_id=""):
+    message = {"Event": event_type}
+    if instance_id:
+        message["EC2InstanceId"] = instance_id
     return {
         "Records": [
             {
                 "EventSource": "aws:sns",
                 "Sns": {
-                    "Message": f'{{"Event": "{event_type}"}}',
+                    "Message": json.dumps(message),
                 },
             }
         ]
@@ -535,11 +538,21 @@ def test_lambda_e2e_with_open_sg(e2e_test_env, with_error):
     ids=["http_api", "rest_api"],
 )
 @moto.mock_aws
-def test_lambda_function(event_data):
-    """Test the lambda function returns the controller version fetched from S3"""
+def test_lambda_function(event_data, monkeypatch):
+    """Test the lambda function returns the controller version fetched from S3.
+
+    A function URL request must not perform controller instance discovery: it
+    does not need the instance, and doing so would log a spurious error when the
+    Name tag is ambiguous. Assert get_controller_instance is never called.
+    """
     os.environ["S3_BUCKET_REGION"] = "us-west-2"
     s3 = boto3.client("s3")
     os.environ["PRIV_IP"] = priv_ip = "10.20.30.40"
+
+    def fail_if_called(*args, **kwargs):
+        pytest.fail("get_controller_instance should not run for a function event")
+
+    monkeypatch.setattr(aviatrix_ha, "get_controller_instance", fail_if_called)
 
     s3.create_bucket(Bucket=os.environ["S3_BUCKET_BACK"])
     s3.put_object(

--- a/tests/test_lambda.py
+++ b/tests/test_lambda.py
@@ -82,7 +82,9 @@ def _sns_message(event_type):
     }
 
 
-def mock_send_response(event, context, status, reason, **kwargs):
+def mock_send_response(
+    event, context, status, reason="", response_data=None, physical_resource_id=None
+):
     if status != "SUCCESS":
         pytest.fail(f"{status}: {reason}")
 


### PR DESCRIPTION
HA setup was failed with "Cannot find backup file in the bucket", but the real CloudWatch error was a 403 on S3 HeadObject. After digging in a lot more, there were actually two separate issues behind the scene.

Issue 1: HA setup picked the wrong controller during stack creation.
Our old logic find the controller by its Name tag. The Name tag is NOT unique - a customer can have multiple running instances with the same Name tag. The old code just grabbed the first match (`Reservations[0]["Instances"][0]`), so HA could silently select the wrong controller. It then looked up that controller's backup by its private IP and asked for a backup that belonged to a different controller - which doesn't exist, so the lookup failed. The live controller was `10.0.0.52`, but the only backup in the bucket was `CloudN_10.0.0.109_*` from a different instance that shared the same Name tag.

Issue 2: A missing backup looked like a permission error
`download_fileobj` does a HeadObject first. Without `s3:ListBucket`, S3 returns 403 instead of 404 for an object 
that simply doesn't exist. So a missing backup showed up as "access denied", which sent us digging into IAM/KMS/bucket-policy rabbit-hole for a while before we realized the file just wasn't there.

Thus we did couple fixes:
- `get_controller_instance` no longer grabs the first match. It lists all running instances with Name tag, if more than one matches, it uses controller private ip to distinguish to pick the right one. If it still can't narrow down to a single instance, it returns a clear error instead of guessing. The instance-id fallback logic (for a stopped or renamed controller) is improved cause it will cause issue within the same multiple controller share the same controller instance name setup.
- New stack parameter `ControllerPrivateIpParam` so the user tells us which controller they mean. The private IP is unique within a VPC, so it's a reliable way to choose between instances that share a Name tag.
- Added `s3:ListBucket` to the Lambda role. Now a genuinely missing backup returns a clean 404 ("Cannot find backup file") instead of a misleading 403.
- `verify_backup_file` now prints a distinct message for a real 403 (object exists but unreadable - ownership / bucket policy / KMS)
- Updated CTRL_PRIV_IP after a successful failover to make sure second failover will work with right controller we just restored

Tests:
- Added tests/test_get_controller_instance.py.
- Fixed mock_send_response in test_lambda.py which failed before our fix.

One caveat:
The private IP is only used to choose between multiple Name tag matches - it never rejects a single match. This is needed for failover: the ASG replacement gets a new private IP that won't match the one provided, but at that point it's the only instance with the Name tag, so we still will select the right one.

Test:
Verified that this is working given two instances shared the same name
ASG works fine as well with failover stage, plus the CTRL_PRIV_IP has been updated to the new brought up restored controller's private ip
```
aws lambda get-function-configuration --function-name dguo-test-controller-ha     --region us-east-1 --query "Environment.Variables.CTRL_PRIV_IP" --output text
10.0.9.53
```
<img width="1682" height="725" alt="image" src="https://github.com/user-attachments/assets/a57a6a92-e42e-43f5-8464-c4b950dc0a47" />
<img width="2684" height="999" alt="image" src="https://github.com/user-attachments/assets/5bc2ed24-2208-406b-8f60-1ebf7678095f" />
<img width="3307" height="1311" alt="image" src="https://github.com/user-attachments/assets/1c69efb2-3475-4b4a-ad7e-d76141645733" />
