### PR TITLE
AVX-78782: Mirroring original controller's instance metadata options when ASG is launching from template

### DIFF
--- a/aviatrix_ha/csp/lambda_c.py
+++ b/aviatrix_ha/csp/lambda_c.py
@@ -96,6 +96,20 @@ def set_environ(
         if not key.startswith("aws:"):
             tags_stripped.append(tag)
 
+    # Mirror the original controller's IMDS configuration onto the launch template.
+    metadata_options_resp = controller_instanceobj.get("MetadataOptions", {})
+    metadata_options = {
+        key: metadata_options_resp[key]
+        for key in (
+            "HttpTokens",
+            "HttpPutResponseHopLimit",
+            "HttpEndpoint",
+            "HttpProtocolIpv6",
+            "InstanceMetadataTags",
+        )
+        if key in metadata_options_resp
+    }
+
     disks = []
     for volume in controller_instanceobj.get("BlockDeviceMappings", []):
         ebs = volume.get("Ebs", {})
@@ -145,6 +159,7 @@ def set_environ(
         "IAM_ARN": iam_arn,
         "MONITORING": monitoring,
         "DISKS": json.dumps(disks),
+        "METADATA_OPTIONS": json.dumps(metadata_options),
         "TAGS": json.dumps(tags_stripped),
         "TMP_SG_GRP": os.environ.get("TMP_SG_GRP", ""),
         "TMP_SG_RULE": os.environ.get("TMP_SG_RULE", ""),
@@ -193,6 +208,7 @@ def update_env_dict(
         "IAM_ARN": os.environ.get("IAM_ARN", ""),
         "MONITORING": os.environ.get("MONITORING", ""),
         "DISKS": os.environ.get("DISKS", ""),
+        "METADATA_OPTIONS": os.environ.get("METADATA_OPTIONS", "{}"),
         "TAGS": os.environ.get("TAGS", "[]"),
         "TMP_SG_GRP": os.environ.get("TMP_SG_GRP", ""),
         "TMP_SG_RULE": os.environ.get("TMP_SG_RULE", ""),

--- a/aviatrix_ha/csp/lambda_c.py
+++ b/aviatrix_ha/csp/lambda_c.py
@@ -9,6 +9,14 @@ from types_boto3_lambda.client import LambdaClient
 
 from aviatrix_ha.errors.exceptions import AvxError
 
+LAUNCH_TEMPLATE_METADATA_OPTION_KEYS = (
+    "HttpTokens",
+    "HttpPutResponseHopLimit",
+    "HttpEndpoint",
+    "HttpProtocolIpv6",
+    "InstanceMetadataTags",
+)
+
 
 def wait_function_update_successful(
     lambda_client: LambdaClient, function_name: str, raise_err: bool = False
@@ -100,13 +108,7 @@ def set_environ(
     metadata_options_resp = controller_instanceobj.get("MetadataOptions", {})
     metadata_options = {
         key: metadata_options_resp[key]
-        for key in (
-            "HttpTokens",
-            "HttpPutResponseHopLimit",
-            "HttpEndpoint",
-            "HttpProtocolIpv6",
-            "InstanceMetadataTags",
-        )
+        for key in LAUNCH_TEMPLATE_METADATA_OPTION_KEYS
         if key in metadata_options_resp
     }
 

--- a/aviatrix_ha/handlers/cft/create.py
+++ b/aviatrix_ha/handlers/cft/create.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import time
-from typing import Any
+from typing import Any, cast
 import uuid
 
 from aviatrix_ha.handlers.cft.delete import delete_launch_template
@@ -12,6 +12,7 @@ import botocore
 from types_boto3_ec2.literals import InstanceTypeType
 from types_boto3_ec2.type_defs import (
     LaunchTemplateBlockDeviceMappingRequestTypeDef,
+    LaunchTemplateInstanceMetadataOptionsRequestTypeDef,
     RequestLaunchTemplateDataTypeDef,
 )
 import yaml
@@ -120,7 +121,7 @@ def _create_launch_template(
     ec2_client,
     lt_name: str,
     ami_id: str,
-    inst_type: str,
+    inst_type: InstanceTypeType,
     key_name: str,
     sg_list: list[str],
     user_data: str,
@@ -131,6 +132,7 @@ def _create_launch_template(
     disable_api_term: bool,
     unique_tags: dict,
     cf_tags: list,
+    metadata_options: LaunchTemplateInstanceMetadataOptionsRequestTypeDef,
 ) -> None:
     cloud_init = _update_user_data(user_data).encode("utf-8")
 
@@ -148,6 +150,7 @@ def _create_launch_template(
         ],
         "SecurityGroupIds": sg_list,
         "UserData": base64.b64encode(cloud_init).decode("utf-8"),
+        "MetadataOptions": metadata_options,
         # # Unused and unsupported parameters
         # Placement, (az info) # RamDiskId # 'NetworkInterfaces' # 'KernelId':  '',
         # 'SecurityGroups': sg_list  # for non-default VPC only SG is supported by AWS
@@ -156,7 +159,7 @@ def _create_launch_template(
         # 'UserData': "'IyBJZ25vcmU='",# base64.b64encode("# Ignore".encode()).decode()
         # SecurityGroups(specified in asg) # InstanceMarketOptions(spot)
         # CreditSpecification # CpuOptions # CapacityReservationSpecification
-        # LicenseSpecifications # HibernationOptions # MetadataOptions # EnclaveOptions
+        # LicenseSpecifications # HibernationOptions # EnclaveOptions
         # InstanceRequirements # PrivateDnsNameOptions # MaintenanceOptions
     }
 
@@ -315,6 +318,15 @@ def setup_ha(
     iam_arn = os.environ.get("IAM_ARN", "")
     monitoring = os.environ.get("MONITORING", "disabled") == "enabled"
     ebz_optimized = os.environ.get("EBS_OPT", "False") == "True"
+    # Mirror the source controller's IMDS configuration so the replacement
+    # inherits IMDSv2 enforcement (e.g. HttpTokens: required). Without this
+    # the instance defaults to the account/region setting and RunInstances is
+    # denied in environments with an SCP mandating IMDSv2. Empty when the
+    # source had no explicit config, which leaves the account/region default.
+    metadata_options = cast(
+        LaunchTemplateInstanceMetadataOptionsRequestTypeDef,
+        json.loads(os.environ.get("METADATA_OPTIONS", "{}")),
+    )
     if inst_id:
         print("Setting launch template from instance")
 
@@ -384,6 +396,7 @@ def setup_ha(
         disable_api_term,
         unique_tags,
         cf_tags,
+        metadata_options,
     )
 
     # Step 3: Create or Update ASG

--- a/tests/test_metadata_options.py
+++ b/tests/test_metadata_options.py
@@ -1,0 +1,67 @@
+"""Tests for mirroring the source controller's IMDS configuration.
+
+Controller HA must copy the original controller's MetadataOptions onto the ASG
+launch template. Otherwise a replacement launched during failover inherits the
+account/region default (HttpTokens: optional) and in an environment with an SCP
+requiring HttpTokens: required, the RunInstances call is denied and failover
+fails immediately.
+"""
+
+import boto3
+import moto
+import pytest
+
+from aviatrix_ha.handlers.cft.create import _create_launch_template
+
+MOTO_AMI_ID = "ami-12c6146b"
+
+
+@pytest.fixture
+def ec2_client():
+    with moto.mock_aws():
+        yield boto3.client("ec2", region_name="us-east-1")
+
+
+def _get_lt_data(ec2_client, lt_name):
+    version = ec2_client.describe_launch_template_versions(LaunchTemplateName=lt_name)[
+        "LaunchTemplateVersions"
+    ][0]
+    return version["LaunchTemplateData"]
+
+
+def _create(ec2_client, lt_name, metadata_options):
+    _create_launch_template(
+        ec2_client,
+        lt_name=lt_name,
+        ami_id=MOTO_AMI_ID,
+        inst_type="t3.large",
+        key_name="",
+        sg_list=["sg-12345678"],
+        user_data="",
+        bld_map=[],
+        iam_arn="arn:aws:iam::123456789012:instance-profile/test",
+        monitoring=False,
+        ebz_optimized=False,
+        disable_api_term=False,
+        unique_tags={("Name", "ctrl"): {"Key": "Name", "Value": "ctrl"}},
+        cf_tags=[],
+        metadata_options=metadata_options,
+    )
+
+
+def test_launch_template_mirrors_metadata_options(ec2_client):
+    """IMDSv2 enforcement from the source controller lands on the template."""
+    metadata_options = {"HttpTokens": "required", "HttpEndpoint": "enabled"}
+    _create(ec2_client, "lt-imdsv2", metadata_options)
+
+    lt_data = _get_lt_data(ec2_client, "lt-imdsv2")
+    assert lt_data["MetadataOptions"]["HttpTokens"] == "required"
+    assert lt_data["MetadataOptions"]["HttpEndpoint"] == "enabled"
+
+
+def test_launch_template_no_metadata_options_when_empty(ec2_client):
+    """With no source config we fall back to the account/region default."""
+    _create(ec2_client, "lt-default", {})
+
+    lt_data = _get_lt_data(ec2_client, "lt-default")
+    assert "MetadataOptions" not in lt_data


### PR DESCRIPTION
This is a feature request, the fix is pretty straightforward and aim to maintain backward compatibility as well.

The initiative is that Controller HA cannot enforce IMDSv2 in replacement controller (EC2 LaunchTemplate created by cft and used by ASG), thus we should mirroring whatever the original controller's instance metadata config, passed in as a parameter then update onto the launch template.

This way a controller with `HttpTokens: required` status should failover successfully and deploy a replacement controller with same metadata config.

Manually tested, before the failover and after the failover, instance metadata config the same
<img width="830" height="139" alt="image" src="https://github.com/user-attachments/assets/2b0c32a2-d9e9-4a1a-8cce-337a1da21743" />

